### PR TITLE
TAG modifications to accomodate multidocument upload

### DIFF
--- a/inst/tag/server.r
+++ b/inst/tag/server.r
@@ -20,12 +20,10 @@ server <- shinyServer(
     
     options(shiny.maxRequestSize = sysram)
     
-    
     ### Load the app
     files <- dir("./shiny", recursive=TRUE, pattern="[.]r$")
     files <- paste0("./shiny/", files)
     for (file in files) source(file=file, local=TRUE)
-    
     
     # Buttons in shiny are really annoying fyi
     set_data(input)

--- a/inst/tag/shiny/pages/analyse/lda.r
+++ b/inst/tag/shiny/pages/analyse/lda.r
@@ -31,6 +31,10 @@ analyse_lda <- function(input)
         incProgress(0, message="Building to dtm...")
         evalfun(DTM <- qdap::as.dtm(localstate$corpus), 
           comment="Build document-term matrix")
+
+        #make sure all rows have nonzero entries     
+        rowTotals <- apply(DTM,1,sum)
+        DTM <- DTM[rowTotals>0, ]
         
         incProgress(1/2, message="Fitting the model...")
         evalfun(localstate$lda_mdl <- topicmodels::LDA(DTM, k=input$lda_ntopics, method=input$lda_method), 

--- a/inst/tag/shiny/pages/data/filter.r
+++ b/inst/tag/shiny/pages/data/filter.r
@@ -20,27 +20,26 @@ output$data_filter <- renderUI({
         # Custom
         conditionalPanel(condition = "input.data_filter_type == 'custom'",
           br(),
-          checkboxInput("data_filter_checkbox_greedy", "Exclude greedily?", value=FALSE),
-          checkboxInput("data_filter_checkbox_greedy", "Exclude ignores case?", value=FALSE),
+          #checkboxInput("data_filter_checkbox_greedy", "Exclude greedily?", value=FALSE),
+          #checkboxInput("data_filter_checkbox_greedy", "Exclude ignores case?", value=FALSE),
           textInput("data_filter_exclude", "Exclude Text"),
           actionButton("button_data_filter_custom", "Filter Custom"),
           hr()
         ),
         
-        
         render_helpfile("Data Filter", "data/filter.md")
       ),
+
       mainPanel(
         renderUI({
           must_have("corpus")
-          
           a <- data_filter_stopwords_reactive()
           b <- data_filter_custom_reactive()
-          
-          if (!is.null(a)) a
-          else
-            b
+          if (!is.null(a)){ a() }
+          else{ b() }
+          localstate$input_out 
         })
+
       )
     )
   )
@@ -50,61 +49,64 @@ output$data_filter <- renderUI({
 
 data_filter_stopwords_reactive <- eventReactive(input$button_data_filter_stopwords, {
   withProgress(message='Processing...', value=0, {
-    
     addto_call("### Filter stopwords\n")
-    
     runtime <- system.time({
-      incProgress(0, message="Removing stopwords...")
-      evalfun(localstate$corpus <- tm::tm_map(localstate$corpus, tm::removeWords, tm::stopwords(input$data_filter_stopwords_lang)), 
-        comment="Remove stopwords")
-      
+      incProgress(0, message="Converting to Lower Case...")
+      evalfun(localstate$corpus <- tm::tm_map(localstate$corpus, tm::content_transformer(tolower)), 
+              comment="Transform to Lower Case")
+      incProgress(1/2, message="Removing Stopwords...")
+      evalfun(localstate$corpus <- tm::tm_map(localstate$corpus, tm::removeWords, 
+                                              tm::stopwords(input$data_filter_stopwords_lang)), 
+              comment="Remove Stopwords")
       clear_secondary()
-      
       addto_call("\n")
-      
       clear_modelstate()
     })
-    
     setProgress(1)
   })
-  
   paste("Processing finished in", round(runtime[3], roundlen), "seconds.")
+
+  localstate$input_out <- HTML("")
 })
-
-
+observe(data_filter_stopwords_reactive())
 
 
 data_filter_custom_reactive <- eventReactive(input$button_data_filter_custom, {
-  withProgress(message='Processing...', value=0, {
-    
-    addto_call("### Filter custom list\n")
-    
-    runtime <- system.time({
-      
-      if (input$data_filter_exclude != "")
-      {
+  if (input$data_filter_exclude != "")
+  {
+    withProgress(message='Processing...', value=0, {
+      addto_call("### Filter custom list\n")
+      runtime <- system.time({
+        incProgress(0, message="Converting to Lower Case...")
+        evalfun(localstate$corpus <- tm::tm_map(localstate$corpus, tm::content_transformer(tolower)), 
+              comment="Transform to Lower Case")
+        incProgress(0, message="Removing Custom Stopwords...")
         evalfun({
           terms <- input$data_filter_exclude
+          #convert exclusion words to lower case
+          terms <- tolower(terms) 
           terms <- unlist(strsplit(terms, split=","))
-          
           localstate$corpus <- tm::tm_map(localstate$corpus, tm::removeWords, terms)
-        })
-      }
-      else
-        stop("Exclusion list is empty!")
-      
-      cleare_secondary()
-      
-      addto_call("\n")
-      
-      clear_modelstate()
+        },comment="Remove Custom Stopwords")
+        clear_secondary()
+        addto_call("\n")
+        clear_modelstate()
+        setProgress(1)
+      })
+      paste("Processing finished in", round(runtime[3], roundlen), "seconds.")
     })
-    
-    setProgress(1)
-  })
-  
-  paste("Processing finished in", round(runtime[3], roundlen), "seconds.")
+  localstate$input_out <- HTML("")
+  }
+  else
+  {
+    #stop("Exclusion list is empty!")
+    localstate$input_out <- HTML("Exclusion list is empty!")
+  }
 })
+observe(data_filter_custom_reactive())
+
+
+
 
 ### TODO
 #        terms <- input$data_filter_exclude

--- a/inst/tag/shiny/pages/data/input.r
+++ b/inst/tag/shiny/pages/data/input.r
@@ -33,7 +33,6 @@ clean_corpus <- function()
   #reset any analysis objects to null.
   localstate$lda_mdl <- NULL
   localstate$ng_mdl <- NULL 
-  #localstate$input_out <- HTML(paste("inspect(corpus)= [\n\n ", inspect(localstate$corpus), " \n\n]"))
 }
 
 
@@ -105,9 +104,10 @@ output$data_import <- renderUI({
       conditionalPanel(condition = "input.data_input_type == 'custom' && input.data_input_method_custom == 'files'",
         br(),
         fileInput('data_localtext_files', label="Input File", multiple=TRUE, 
-        accept=c('text/plain','text/csv','text/tab-separated-values','text/richtext','application/excel','text/x-c') 
-        )
-                   #accept=c('text/csv','text/tab-separated-values','text/plain','application/plain','application/excel','text/x-c','text/x-fortran','text/x-h','text/richtext',".cpp",'.hpp','application/pdf','application/msword')
+          # We can add more file types to upload, but anything other than text types will likely crash during processing. 
+          # To use pdf or word files, preprocessing them into text format will be necessary 
+          accept=c('text/plain','text/csv','text/tab-separated-values','text/richtext','text/x-c') 
+        ) 
       ),
 
       # Text box
@@ -164,6 +164,8 @@ set_data <- function(input)
   # Local files
   tmp <- eventReactive(input$data_localtext_files, {
     textdir <- input$data_localtext_files
+    #remove non ascii characters 
+    textdir$datapath[1] <- iconv(textdir$datapath[1], "", "ASCII", sub="")
     if (!is.null(textdir))
     {
       if(!input$data_import_checkbox_append_document_list){ clear_state() }

--- a/inst/tag/shiny/pages/data/inspect.r
+++ b/inst/tag/shiny/pages/data/inspect.r
@@ -8,21 +8,24 @@ output$data_inspect_ <- DT::renderDataTable({
   must_have("corpus")
   
   withProgress(message='Collapsing the corpus...', value=0, {
+
     dt <- sapply(localstate$corpus, function(elem) elem$content)
     names(dt) <- NULL
     dim(dt) <- c(length(dt), 1L)
     colnames(dt) <- "Corpus"
     
     incProgress(3/4, message="Rendering...")
-    DT::datatable(dt, extensions="Scroller", escape=TRUE,
-      options = list(
-        deferRender = TRUE,
-        dom = "frtiS",
-        scrollY = 300,
-        width = 500,
-        scrollCollapse = TRUE
-      )
-    )
+
+    DT::datatable(dt, 
+                  extensions="Scroller", 
+                  escape=TRUE,
+                  options = list( deferRender = TRUE,
+                                  dom = "frtiS",
+                                  scrollY = 300,
+                                  width = 500,
+                                  scrollCollapse = TRUE
+                                )
+                 )
   })
 })
 

--- a/inst/tag/shiny/pages/explore/summary.r
+++ b/inst/tag/shiny/pages/explore/summary.r
@@ -45,8 +45,8 @@ output$explore_summary_ <- renderUI({
   must_have("corpus")
   must_have("tdm")
   
-  s <- TAG::wc(sapply(localstate$corpus, function(i) i$content), input$explore_corpus_maxwordlen, input$explore_corpus_maxsenlen)
-  
+  s <- TAG::wc(unlist(sapply(localstate$corpus, function(elem) elem$content)), input$explore_corpus_maxwordlen, input$explore_corpus_maxsenlen)
+
   verticalLayout(
     ### Top row
     fluidRow(


### PR DESCRIPTION
Multiple documents can now be uploaded from a local directory, or appended to the corpus using any of the available input methods by clicking on an "append to list" checkbox in the input dialog. 
Some modifications such a removing empty documents and non ascii characters, were made to ensure uploaded documents did not crash the gateway or lead to unexpected behavior.
The only known issue is that very large corpuses do not display in the inspect tab.
